### PR TITLE
Explicily throw errors on az cli failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
+
+      # there is an issue with az cli and python 3.14, so for now we need to pin it
+      # once the issue is resolved it should be able to be re-floated
+      # https://github.com/Azure/azure-cli/issues/32980
+      - name: Set Python 3.13 (Linux)
+        if: matrix.os-name == 'Linux' && matrix.test-category == 'AzureServiceBus'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install pinned Azure CLI on Python 3.13 (Linux)
+        if: matrix.os-name == 'Linux' && matrix.test-category == 'AzureServiceBus'
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --user "azure-cli==2.64.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          
       - name: Azure login
         if: ${{ matrix.needs-azure-login == true }}
         uses: azure/login@v3.0.0

--- a/setup.ps1
+++ b/setup.ps1
@@ -390,18 +390,34 @@ function Setup-Azure {
 
     Write-Output "Creating Azure Service Bus namespace $ASBName (This can take a while.)"
     $details = az servicebus namespace create --resource-group $resourceGroup --name $ASBName --location $region --tags $packageTag $runnerOsTag $dateTag | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create Azure Service Bus namespace $ASBName in resource group $resourceGroup."
+    }
 
     Write-Output "Assigning roles to Azure Service Bus namespace $ASBName"
     az role assignment create --assignee $credentials.principalId --role "Azure Service Bus Data Owner" --scope $details.id > $null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to assign roles to Azure Service Bus namespace $ASBName."
+    }
 
     Write-Output "Getting connection string"
     $keys = az servicebus namespace authorization-rule keys list --resource-group $resourceGroup --namespace-name $ASBName --name RootManageSharedAccessKey | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to get connection string for Azure Service Bus namespace $ASBName."
+    }
     $connectString = $keys.primaryConnectionString
     Write-Output "::add-mask::$connectString"
 
     Write-Output "Getting connection string without manage rights"
     az servicebus namespace authorization-rule create --resource-group $resourceGroup --namespace-name $ASBName --name RootNoManageSharedAccessKey --rights Send Listen > $null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create authorization rule without manage rights for Azure Service Bus namespace $ASBName."
+    }
+
     $noManageKeys = az servicebus namespace authorization-rule keys list --resource-group $resourceGroup --namespace-name $ASBName --name RootNoManageSharedAccessKey | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to get connection string without manage rights for Azure Service Bus namespace $ASBName."
+    }
     $noManageConnectString = $noManageKeys.primaryConnectionString
     Write-Output "::add-mask::$noManageConnectString"
 


### PR DESCRIPTION
There were failures in ServiceControl pipelines that were not being reported as errors in this action, added explicit return code checks to the `az` cli calls during setup.